### PR TITLE
Fix read/write permissions for login

### DIFF
--- a/app/code/local/VinaiKopp/Api2SessionLogin/Model/Api2/Customer/Session.php
+++ b/app/code/local/VinaiKopp/Api2SessionLogin/Model/Api2/Customer/Session.php
@@ -94,6 +94,11 @@ class VinaiKopp_Api2SessionLogin_Model_Api2_Customer_Session
                     if ($this->getResponse()->isException()) {
                         break;
                     }
+
+                    // This fixes a 'bug' with calling in() and out() on the same filter in one request
+                    /** @var $filter Mage_Api2_Model_Acl_Filter */
+                    $filter = Mage::getModel('api2/acl_filter', $this);
+                    $this->setFilter($filter);
                 }
             // break statement left out intentionally!
 

--- a/app/code/local/VinaiKopp/Api2SessionLogin/etc/api2.xml
+++ b/app/code/local/VinaiKopp/Api2SessionLogin/etc/api2.xml
@@ -35,8 +35,7 @@
                         <retrieve>1</retrieve>
                     </guest>
                 </privileges>
-                <attributes translate="isloggedin login password"
-                            module="vinaikopp_api2sessionlogin">
+                <attributes translate="isloggedin login password" module="vinaikopp_api2sessionlogin">
                     <isloggedin>Is Logged In</isloggedin>
                     <login>Login</login>
                     <password>Password</password>
@@ -49,12 +48,22 @@
                             <login>1</login>
                             <password>1</password>
                         </read>
+                        <write>
+                            <isloggedin>1</isloggedin>
+                            <firstname>1</firstname>
+                            <lastname>1</lastname>
+                        </write>
                     </customer>
                     <guest>
                         <read>
                             <login>1</login>
                             <password>1</password>
                         </read>
+                        <write>
+                            <isloggedin>1</isloggedin>
+                            <firstname>1</firstname>
+                            <lastname>1</lastname>
+                        </write>
                     </guest>
                 </exclude_attributes>
                 <routes>


### PR DESCRIPTION
The create->retreive fall-through caused the in/out filter to be broken due to class level caching.
This fixes that bug and update the read/write attributes to reflect reality.
GET requests only return 'firstname', 'lastname', and 'isloggedin'.
POST requests only accept 'login' and 'password' now.
POST requests only return 'firstname', 'lastname', and 'isloggedin'.
