### PR TITLE
Change how invalid logins are reported

### DIFF
--- a/app/code/local/VinaiKopp/Api2SessionLogin/Model/Api2/Customer/Session.php
+++ b/app/code/local/VinaiKopp/Api2SessionLogin/Model/Api2/Customer/Session.php
@@ -160,9 +160,12 @@ class VinaiKopp_Api2SessionLogin_Model_Api2_Customer_Session
             $helper->startFrontendSession();
             $session = $this->getSession();
             $session->login($data['login'], $data['password']);
-        } catch (Mage_Core_Exception $e) {
-            $this->_error($e->getMessage(), Mage_Api2_Model_Server::HTTP_UNAUTHORIZED);
         } catch (Exception $e) {
+            if ($e instanceof Mage_Core_Exception) {
+                if ($e->getCode() == Mage_Customer_Model_Customer::EXCEPTION_INVALID_EMAIL_OR_PASSWORD || $e->getCode() == Mage_Customer_Model_Customer::EXCEPTION_EMAIL_NOT_CONFIRMED) {
+                    throw new Mage_Api2_Exception($e->getMessage(), Mage_Api2_Model_Server::HTTP_UNAUTHORIZED);
+                }
+            }
             $this->_critical(self::RESOURCE_INTERNAL_ERROR);
         }
     }

--- a/app/code/local/VinaiKopp/Api2SessionLogin/Model/Api2/Customer/Session.php
+++ b/app/code/local/VinaiKopp/Api2SessionLogin/Model/Api2/Customer/Session.php
@@ -166,6 +166,7 @@ class VinaiKopp_Api2SessionLogin_Model_Api2_Customer_Session
                     throw new Mage_Api2_Exception($e->getMessage(), Mage_Api2_Model_Server::HTTP_UNAUTHORIZED);
                 }
             }
+            Mage::logException($e);
             $this->_critical(self::RESOURCE_INTERNAL_ERROR);
         }
     }


### PR DESCRIPTION
Don't use the _error call to indicate a login failure, use the same method as the API 403 response.
This prevents a generic error wrapping the 401 error.
